### PR TITLE
《A》再: CHIKYU-5729 PHP5.6に未対応のコードを修正 

### DIFF
--- a/lib/Config/ApiConfig.php
+++ b/lib/Config/ApiConfig.php
@@ -47,15 +47,27 @@ class ApiConfig {
     }
 
     static function host() {
-        return self::HOSTS[self::mode()] ?? 'gateway.chikyu.mobi';
+        // PHP5.6なのでNull合体演算子は使用不可
+        if(isset(self::HOSTS[self::mode()])) {
+            return self::HOSTS[self::mode()];
+        }
+        return 'gateway.chikyu.mobi';
     }
 
     static function protocol() {
-        return self::PROTOCOLS[self::mode()] ?? 'https';
+        // PHP5.6なのでNull合体演算子は使用不可
+        if(isset(self::PROTOCOLS[self::mode()])) {
+            return self::PROTOCOLS[self::mode()];
+        }
+        return 'https';
     }
 
     static function envName() {
-        return self::ENV_NAMES[self::mode()] ?? self::mode();
+        // PHP5.6なのでNull合体演算子は使用不可
+        if(isset(self::PROTOCOLS[self::mode()])) {
+            return self::PROTOCOLS[self::mode()];
+        }
+        return 'https';
     }
 
     static function mode() {


### PR DESCRIPTION
SDKリリース後に不具合が発生しRevertされたため、再度PR作成
[前回のPR](https://github.com/chikyuinc/chikyu-sdk-php/pull/10)