### PR TITLE
《A》再々: CHIKYU-5729  PHP5.6に未対応のコードを修正""

### DIFF
--- a/lib/Config/ApiConfig.php
+++ b/lib/Config/ApiConfig.php
@@ -47,15 +47,27 @@ class ApiConfig {
     }
 
     static function host() {
-        return self::HOSTS[self::mode()] ?? 'gateway.chikyu.mobi';
+        // PHP5.6なのでNull合体演算子は使用不可
+        if(isset(self::HOSTS[self::mode()])) {
+            return self::HOSTS[self::mode()];
+        }
+        return 'gateway.chikyu.mobi';
     }
 
     static function protocol() {
-        return self::PROTOCOLS[self::mode()] ?? 'https';
+        // PHP5.6なのでNull合体演算子は使用不可
+        if(isset(self::PROTOCOLS[self::mode()])) {
+            return self::PROTOCOLS[self::mode()];
+        }
+        return 'https';
     }
 
     static function envName() {
-        return self::ENV_NAMES[self::mode()] ?? self::mode();
+        // PHP5.6なのでNull合体演算子は使用不可
+        if(isset(self::ENV_NAMES[self::mode()])) {
+            return self::ENV_NAMES[self::mode()];
+        }
+        return self::mode();
     }
 
     static function mode() {


### PR DESCRIPTION
---
### リリース予定日(変更された場合は過去のものをすべて残す)

__以下のいずれか__
* 次回リリース時 (タイトルには「次回」と入れる)
  * 急ぎではない不具合や、エンジニア向けのツールなど
    * 不具合修正だが、このプルリクエスト都合でリリース日を決めるほどではないもの
    * リファクタリングなど、不具合修正ではない改善で急がないもの
    * このファイルの編集や、エンジニア向けのツール


### 開発種別および内容（該当するものを残す）

(A) Hotfix

### 開発フロー（進捗度をマーク）

* [x] 企画・要件の記載
* [x] 企画・要件の承認
* [x] テスト結果記載
* [x] 最終レビュー待ち
* [ ] レビュワーLGTM
* [ ] PdMレビューLGTM
* [ ] リリース承認
* [ ] リリース後動作確認


### 背景・経緯の説明
https://github.com/chikyuinc/chikyu-sdk-php/pull/12
上記PRを取り込みデグレを引き起こしたため、再度PR作成。

### 企画・要件の説明

* (A) ここに直接記載（Confluenceのリンクも可）
* 関連チケット
     * https://geniee.atlassian.net/browse/CHIKYU-5729
     * https://geniee.atlassian.net/browse/CHIKYU-5741
* 修正・動作確認の流れ
     1. SDKのバージョンのPHP5.6に対応していない三項演算子(正確にはNull合体演算子)の記述があるので、ifに修正
    
    2. SDKにある既存のテストコードを使ってテストを実施
     
    3. SDKでブランチを切ってpush。その後chikyu側でhttps://github.com/chikyuinc/chikyu/blob/master/var/www/composer.json#L3 を一時的に変える。(取得するSDKのブランチ)
     
    4. chikyuのdev-phpに入って`composer update`を行い、ローカルで以下の確認。
         + ログインが正常に出来ること 
         + レコード作成→保存が正常に出来ること
     
    5. conmposer.jsonを変えたまま、devにビルドし、ローカルと同じように動作確認。
     
    6. devで以下の確認を行う
         * フロントのビルドが反映されていること(ログイン画面のhtmlの値が変わっているか)
         * ログインが正常に出来ること 
         * レコード作成→保存が正常に出来ること

### リリース承認記録へのリンク

* (A) プルリクエストのコメントに承認者が承認したことを記載(ここは空欄で良い)
  * 承認権限は Leader以上 が持つ


### テスト内容及び結果

* 環境: devdc
* 確認項目
    + SDKの既存のテストコードが通ること
    + フロントのビルドが反映されていること
    + ログインが正常に出来ること 
    + レコード作成→保存が正常に出来ること
* 確認結果  
    1. SDKの既存コードを使ったテスト
        * api_test_01.phpの実行結果 
        ![スクリーンショット 2022-08-01 11 58 21](https://user-images.githubusercontent.com/108509565/182068883-929d8871-96c6-4e0a-ac7b-00ad4a3b306b.png)


    
    2. devでの動作確認
        * 取り込んだブランチ
            * https://github.com/chikyuinc/chikyu/commits/test/takeya-kojima/CHIKYU-5729 
        
        * jenkinsビルド詳細(2022/07/29 15:32)
            * https://dev-ci.chikyu.mobi/jenkins/view/devdc/job/package-and-deploy-devdc/807/parameters/

        * ログイン画面(フロントのビルドが反映されてるのがわかるようhtml修正)
        ![スクリーンショット 2022-07-29 16 19 56](https://user-images.githubusercontent.com/108509565/182068010-7d21cf92-a84f-41c3-9a4f-5227b8f8e462.png)


        * ログイン成功後の画面
        ![スクリーンショット 2022-07-29 16 20 49](https://user-images.githubusercontent.com/108509565/182068060-56bcfe2a-41ad-4e87-bb0d-7c0cb7f9d8a0.png)
        
        * レコード作成前後の画面
        ![スクリーンショット 2022-07-29 16 25 27](https://user-images.githubusercontent.com/108509565/182068112-83460a86-4b85-4592-912c-ad8ea49a0a2c.png)
        ![スクリーンショット 2022-07-29 16 25 51](https://user-images.githubusercontent.com/108509565/182068146-4e831894-4961-48ea-84da-98817c20dbd1.png)

       
   
### リリース時の要考慮事項

* __ある場合は列挙(CS・エンジニアへの連絡事項なども記載する)__

### ローカル環境での要考慮事項

* __ある場合は列挙__
1. SDKのバージョンのPHP5.6に対応していない三項演算子(正確にはNull合体演算子)の記述があるので、ifに修正
    
2. SDKにある既存のテストコードを使ってテストを実施
     
3. SDKでブランチを切ってpush。その後chikyu側でhttps://github.com/chikyuinc/chikyu/blob/master/var/www/composer.json#L3 を一時的に変える。(取得するSDKのブランチをmasterから変更)
     
4. chikyuのdev-phpに入って`composer update`を行い、ローカルで以下の確認。
         + ログインが正常に出来ること 
         + レコード作成→保存が正常に出来ること